### PR TITLE
fixed naming problem in EgoStat.nodecov

### DIFF
--- a/R/EgoStat.R
+++ b/R/EgoStat.R
@@ -117,6 +117,7 @@ EgoStat.nodecov <- function(egodata, attr){
                      setNames(data.frame(egoIDcol = alters[[egoIDcol]], stringsAsFactors=FALSE), egoIDcol))
   
   ties.all <-merge(egos[c(egoIDcol,attrnames)],alters[c(egoIDcol,if(alt) attrnames)],by=egoIDcol,suffixes=c(".ego",".alter"))
+  names(ties.all) <- c(egoIDcol, paste0(attrnames, ".ego"), if(alt) paste0(attrnames, ".alter"))
   
   isolates <- egos[[egoIDcol]][!(egos[[egoIDcol]]%in%ties.all[[egoIDcol]])] 
 


### PR DESCRIPTION
to correctly handle the case where the alter attribute is unobserved

sets names manually after merge in case the suffixes are not applied during merge (as when alt = FALSE)

perhaps we should add tests for the case where the alter attributes are unobserved, for terms that allow that?