### PR TITLE
Update ergm.ego to use statnet.data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Description: Utilities for managing egocentrically sampled network data and a wr
 License: GPL-3 + file LICENSE
 URL: https://statnet.org
 BugReports: https://github.com/statnet/ergm.ego/issues
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Roxygen: list(markdown = TRUE)
 Encoding: UTF-8
 Remotes:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,8 @@ Imports:
     dplyr,
     survey,
     stats,
-    methods
+    methods,
+    statnet.data
 Suggests:
     testthat (>= 2.1.1),
     covr (>= 3.2.1)
@@ -41,4 +42,5 @@ Remotes:
     github::statnet/statnet.common@master,
     github::statnet/network@master,
     github::statnet/ergm@master,
-    github::tilltnet/egor
+    github::tilltnet/egor,
+    github::statnet/statnet.data

--- a/R/EgoStat.node.attr.R
+++ b/R/EgoStat.node.attr.R
@@ -82,7 +82,7 @@ NULL
 #'   combination.
 #'
 #' @examples
-#' data(florentine)
+#' data(flomarriage, package="statnet.data")
 #' flomego <- as.egor(flomarriage)
 #' ergm.ego_get_vattr("priorates", flomego)
 #' ergm.ego_get_vattr(~priorates, flomego)

--- a/R/degreedist.R
+++ b/R/degreedist.R
@@ -40,7 +40,7 @@
 #' \code{\link[ergm:summary_formula]{summary}}
 #' @examples
 #' 
-#' data(faux.mesa.high)
+#' data(faux.mesa.high, package="statnet.data")
 #' fmh.ego <- as.egor(faux.mesa.high)
 #' 
 #' degreedist(fmh.ego,by="Grade",brgmod=TRUE)
@@ -177,7 +177,7 @@ degreedist.egor <- function(object, freq = FALSE, prob = !freq,
 #' \code{\link[ergm.ego]{summary}} method for egocentric data
 #' @examples
 #' 
-#' data(faux.mesa.high)
+#' data(faux.mesa.high, package="statnet.data")
 #' fmh.ego <- as.egor(faux.mesa.high)
 #' 
 #' (mm <- mixingmatrix(faux.mesa.high,"Grade"))

--- a/R/egor.R
+++ b/R/egor.R
@@ -117,7 +117,7 @@ as.egor.network<-function(x,special.cols=c("na"),...){
 #' @examples
 #' 
 #' 
-#' data(faux.mesa.high)
+#' data(faux.mesa.high, package="statnet.data")
 #' summary(faux.mesa.high, print.adj = FALSE)
 #' 
 #' fmh.ego <- as.egor(faux.mesa.high)
@@ -211,7 +211,7 @@ na.omit.egor <- function(object, relevant=TRUE, ...){
 #'
 #' @examples
 #'
-#' data(faux.mesa.high)
+#' data(faux.mesa.high, package="statnet.data")
 #' fmh.ego <- as.egor(faux.mesa.high)
 #'
 #' # Create a tiny weighted sample:

--- a/R/ergm.ego.R
+++ b/R/ergm.ego.R
@@ -84,7 +84,7 @@
 #' @seealso \code{\link[ergm]{ergm}()}
 #' @examples
 #' \donttest{
-#' data(faux.mesa.high)
+#' data(faux.mesa.high, package="statnet.data")
 #' fmh.ego <- as.egor(faux.mesa.high)
 #' 
 #' head(fmh.ego)

--- a/R/fmhfit.R
+++ b/R/fmhfit.R
@@ -19,7 +19,7 @@
 #' 
 #' @examples
 #' \dontrun{
-#' data(faux.mesa.high)
+#' data(faux.mesa.high, package="statnet.data")
 #' fmh.ego <- egor::as.egor(faux.mesa.high)
 #' fmhfit <- ergm.ego(
 #'   fmh.ego ~ edges + degree(0:3) + 

--- a/R/gof.ergm.ego.R
+++ b/R/gof.ergm.ego.R
@@ -105,7 +105,7 @@
 #' @keywords models
 #' @examples
 #' \donttest{
-#' data(faux.mesa.high)
+#' data(faux.mesa.high, package="statnet.data")
 #' fmh.ego <- as.egor(faux.mesa.high)
 #' 
 #' head(fmh.ego)

--- a/R/simulate.ergm.ego.R
+++ b/R/simulate.ergm.ego.R
@@ -53,7 +53,7 @@
 #' @keywords models
 #' @examples
 #' 
-#' data(faux.mesa.high)
+#' data(faux.mesa.high, package="statnet.data")
 #' fmh.ego <- as.egor(faux.mesa.high)
 #' data(fmhfit)
 #' colMeans(egosim <- simulate(fmhfit, popsize=300,nsim=50,

--- a/R/summary.statistics.egor.R
+++ b/R/summary.statistics.egor.R
@@ -47,7 +47,7 @@
 #'
 #' @examples
 #' 
-#' data(faux.mesa.high)
+#' data(faux.mesa.high, package="statnet.data")
 #' fmh.ego <- as.egor(faux.mesa.high)
 #' (nw.summ <- summary(faux.mesa.high~edges+degree(0:3)+nodematch("Race")+
 #'                     nodematch("Sex")+absdiff("Grade")+nodemix("Grade")))

--- a/data-raw/fmhfit.R
+++ b/data-raw/fmhfit.R
@@ -1,6 +1,6 @@
 library(ergm.ego)
 
-data(faux.mesa.high)
+data(faux.mesa.high, package="statnet.data")
 fmh.ego <- egor::as.egor(faux.mesa.high)
 fmhfit <- ergm.ego(
   fmh.ego ~ edges + degree(0:3) + 

--- a/man/degreedist.egor.Rd
+++ b/man/degreedist.egor.Rd
@@ -53,7 +53,7 @@ graph.
 }
 \examples{
 
-data(faux.mesa.high)
+data(faux.mesa.high, package="statnet.data")
 fmh.ego <- as.egor(faux.mesa.high)
 
 degreedist(fmh.ego,by="Grade",brgmod=TRUE)

--- a/man/ergm.ego.Rd
+++ b/man/ergm.ego.Rd
@@ -83,7 +83,7 @@ A wrapper around the \code{\link[ergm]{ergm}} to fit an ERGM to an
 }
 \examples{
 \donttest{
-data(faux.mesa.high)
+data(faux.mesa.high, package="statnet.data")
 fmh.ego <- as.egor(faux.mesa.high)
 
 head(fmh.ego)

--- a/man/fmhfit.Rd
+++ b/man/fmhfit.Rd
@@ -13,7 +13,7 @@ shown below in the Examples section.
 }
 \examples{
 \dontrun{
-data(faux.mesa.high)
+data(faux.mesa.high, package="statnet.data")
 fmh.ego <- egor::as.egor(faux.mesa.high)
 fmhfit <- ergm.ego(
   fmh.ego ~ edges + degree(0:3) + 

--- a/man/gof.ergm.ego.Rd
+++ b/man/gof.ergm.ego.Rd
@@ -48,7 +48,7 @@ An enhanced plotting method is also provided, giving uncertainty bars for the ob
 }
 \examples{
 \donttest{
-data(faux.mesa.high)
+data(faux.mesa.high, package="statnet.data")
 fmh.ego <- as.egor(faux.mesa.high)
 
 head(fmh.ego)

--- a/man/mixingmatrix.egor.Rd
+++ b/man/mixingmatrix.egor.Rd
@@ -36,7 +36,7 @@ of each group nominates an alter of each group.
 }
 \examples{
 
-data(faux.mesa.high)
+data(faux.mesa.high, package="statnet.data")
 fmh.ego <- as.egor(faux.mesa.high)
 
 (mm <- mixingmatrix(faux.mesa.high,"Grade"))

--- a/man/nodal_attributes-API.Rd
+++ b/man/nodal_attributes-API.Rd
@@ -164,7 +164,7 @@ beconverted to character).}
 }}
 
 \examples{
-data(florentine)
+data(flomarriage, package="statnet.data")
 flomego <- as.egor(flomarriage)
 ergm.ego_get_vattr("priorates", flomego)
 ergm.ego_get_vattr(~priorates, flomego)

--- a/man/sample.Rd
+++ b/man/sample.Rd
@@ -33,7 +33,7 @@ data-frame-alikes as arguments.
 }
 \examples{
 
-data(faux.mesa.high)
+data(faux.mesa.high, package="statnet.data")
 fmh.ego <- as.egor(faux.mesa.high)
 
 # Create a tiny weighted sample:

--- a/man/simulate.ergm.ego.Rd
+++ b/man/simulate.ergm.ego.Rd
@@ -54,7 +54,7 @@ from an ERGM fit using \code{\link{ergm.ego}}.
 }
 \examples{
 
-data(faux.mesa.high)
+data(faux.mesa.high, package="statnet.data")
 fmh.ego <- as.egor(faux.mesa.high)
 data(fmhfit)
 colMeans(egosim <- simulate(fmhfit, popsize=300,nsim=50,

--- a/man/summary_formula.egor.Rd
+++ b/man/summary_formula.egor.Rd
@@ -53,7 +53,7 @@ Used to calculate the specified network statistics inferred from a
 
 \examples{
 
-data(faux.mesa.high)
+data(faux.mesa.high, package="statnet.data")
 fmh.ego <- as.egor(faux.mesa.high)
 (nw.summ <- summary(faux.mesa.high~edges+degree(0:3)+nodematch("Race")+
                     nodematch("Sex")+absdiff("Grade")+nodemix("Grade")))

--- a/man/template_network.Rd
+++ b/man/template_network.Rd
@@ -35,7 +35,7 @@ taking into accounts their sampling weights.
 \examples{
 
 
-data(faux.mesa.high)
+data(faux.mesa.high, package="statnet.data")
 summary(faux.mesa.high, print.adj = FALSE)
 
 fmh.ego <- as.egor(faux.mesa.high)

--- a/tests/testthat/test-boot_jack.R
+++ b/tests/testthat/test-boot_jack.R
@@ -8,7 +8,7 @@
 #  Copyright 2015-2021 Statnet Commons
 ################################################################################
 
-data(faux.mesa.high)
+data(faux.mesa.high, package="statnet.data")
 fmh.ego <- as.egor(faux.mesa.high)
 
 

--- a/tests/testthat/test-coef_recovery.R
+++ b/tests/testthat/test-coef_recovery.R
@@ -10,7 +10,7 @@
 test_that("complete ERGM and ergm.ego() give similar coef estimates",{
   ergm.ego:::long_test()
 
-  data(faux.mesa.high)
+  data(faux.mesa.high, package="statnet.data")
   fmh.ego <- egor::as.egor(faux.mesa.high)
   
   fit <- ergm(

--- a/tests/testthat/test-degreedist.R
+++ b/tests/testthat/test-degreedist.R
@@ -69,7 +69,7 @@ test_that("degreedist() works on egor::egor32 data with `by=sex` (a factor)", {
 
 # Tests using ergm::faux.mesa.high data -----------------------------------
 
-data(faux.mesa.high, package="ergm")
+data(faux.mesa.high, package="statnet.data")
 fmh.ego <- as.egor(faux.mesa.high)
 
 test_that("degreedist() works on data based on faux.mesa.high", {

--- a/tests/testthat/test-gof.ergm.ego.R
+++ b/tests/testthat/test-gof.ergm.ego.R
@@ -58,7 +58,7 @@ test_that("GOF='espartners' works", {
 
 
 test_that("GOF='espartners' works if `esp` term is in the model", {
-  data("faux.mesa.high", package="ergm")
+  data("faux.mesa.high", package="statnet.data")
   edata <- as.egor(faux.mesa.high)
   fit <- ergm.ego(
     edata ~ edges + esp(1), 

--- a/tests/testthat/test-mixingmatrix.R
+++ b/tests/testthat/test-mixingmatrix.R
@@ -79,7 +79,7 @@ for ( v in varnames ) {
 # })
 
 test_that("mixing matrices for FMH and egoFMH are equivalent", {
-  data("faux.mesa.high")
+  data("faux.mesa.high", package="statnet.data")
   fmh.ego <- as.egor(faux.mesa.high)
   expect_equal(
     {

--- a/tests/testthat/test-netsize.adj.R
+++ b/tests/testthat/test-netsize.adj.R
@@ -7,7 +7,7 @@
 #
 #  Copyright 2015-2021 Statnet Commons
 ################################################################################
-data(sampson, package="ergm")
+data(sampson, package="statnet.data")
 
 for(i in 1:10) {
   set.seed(i)
@@ -30,7 +30,7 @@ for(i in 1:10) {
   })
 }
 
-data(faux.mesa.high, package="ergm")
+data(faux.mesa.high, package="statnet.data")
 
 for(i in 1:10) {
   set.seed(i)

--- a/tests/testthat/test-netsize.adj.R
+++ b/tests/testthat/test-netsize.adj.R
@@ -7,7 +7,7 @@
 #
 #  Copyright 2015-2021 Statnet Commons
 ################################################################################
-data(sampson, package="statnet.data")
+data(samplike, package="statnet.data")
 
 for(i in 1:10) {
   set.seed(i)

--- a/tests/testthat/test-predict.ergm.ego.R
+++ b/tests/testthat/test-predict.ergm.ego.R
@@ -11,7 +11,7 @@
 library(ergm.ego)
 
 test_that("it just works for model without offsets", {
-  data(faux.mesa.high, package="ergm")
+  data(faux.mesa.high, package="statnet.data")
   fmh.ego <- as.egor(faux.mesa.high)
   egofit <- ergm.ego(
     fmh.ego~edges+degree(0:3)+nodefactor("Race")+nodematch("Race")
@@ -26,7 +26,7 @@ test_that("it just works for model without offsets", {
 
 
 test_that("it just works for model with offsets", {
-  data("faux.mesa.high", package="ergm")
+  data("faux.mesa.high", package="statnet.data")
   fmhego <- as.egor(faux.mesa.high)
   fit <- ergm.ego(
     fmhego ~ edges 

--- a/tests/testthat/test-table_ppop.R
+++ b/tests/testthat/test-table_ppop.R
@@ -11,7 +11,7 @@ test_that("estimation works", {
   
   skip("Not yet fixed")
   
-  data(faux.mesa.high)
+  data(faux.mesa.high, package="statnet.data")
   fmh.ego <- as.egor(faux.mesa.high)
   ppop <- rbind(fmh.ego, fmh.ego)
   ppop$.alts <- NULL


### PR DESCRIPTION
These changes will update the package for using data from the `statnet.data` package.

I'm creating this PR to trigger the checks via GH actions, **please refrain from merging** until the `statnet.data` package is on CRAN [![](https://img.shields.io/github/milestones/progress-percent/statnet/statnet.data/1)](https://github.com/statnet/statnet.data/milestone/2).